### PR TITLE
Add airline boardingpass barcode decoding

### DIFF
--- a/app/src/main/java/com/example/barcodescanner/extension/BarcodeSchema.kt
+++ b/app/src/main/java/com/example/barcodescanner/extension/BarcodeSchema.kt
@@ -20,6 +20,7 @@ fun BarcodeSchema.toImageId(): Int? {
         BarcodeSchema.VCARD -> R.drawable.ic_contact
         BarcodeSchema.WIFI -> R.drawable.ic_wifi
         BarcodeSchema.YOUTUBE -> R.drawable.ic_youtube
+        BarcodeSchema.BOARDINGPASS -> R.drawable.ic_boardingpass
         else -> null
     }
 }
@@ -41,6 +42,7 @@ fun BarcodeSchema.toStringId(): Int? {
         BarcodeSchema.VCARD -> R.string.barcode_schema_v_card
         BarcodeSchema.WIFI -> R.string.barcode_schema_wifi
         BarcodeSchema.YOUTUBE -> R.string.barcode_schema_youtube
+        BarcodeSchema.BOARDINGPASS -> R.string.barcode_schema_boardingpass
         BarcodeSchema.OTHER -> R.string.barcode_schema_other
         else -> null
     }

--- a/app/src/main/java/com/example/barcodescanner/feature/barcode/BarcodeActivity.kt
+++ b/app/src/main/java/com/example/barcodescanner/feature/barcode/BarcodeActivity.kt
@@ -148,6 +148,7 @@ class BarcodeActivity : BaseActivity(), DeleteConfirmationDialogFragment.Listene
             BarcodeSchema.WIFI -> connectToWifi()
             BarcodeSchema.YOUTUBE -> openInYoutube()
             BarcodeSchema.NZCOVIDTRACER -> openLink()
+            BarcodeSchema.BOARDINGPASS -> return
             else -> return
         }
     }

--- a/app/src/main/java/com/example/barcodescanner/model/ParsedBarcode.kt
+++ b/app/src/main/java/com/example/barcodescanner/model/ParsedBarcode.kt
@@ -95,6 +95,7 @@ class ParsedBarcode(barcode: Barcode) {
             BarcodeSchema.CRYPTOCURRENCY -> parseBitcoin()
             BarcodeSchema.OTP_AUTH -> parseOtp()
             BarcodeSchema.NZCOVIDTRACER -> parseNZCovidTracer()
+            BarcodeSchema.BOARDINGPASS,
             BarcodeSchema.URL -> parseUrl()
         }
     }

--- a/app/src/main/java/com/example/barcodescanner/model/schema/BoardingPass.kt
+++ b/app/src/main/java/com/example/barcodescanner/model/schema/BoardingPass.kt
@@ -1,0 +1,115 @@
+package com.example.barcodescanner.model.schema
+
+
+import com.example.barcodescanner.extension.joinToStringNotNullOrBlankWithLineSeparator
+import com.example.barcodescanner.extension.startsWithIgnoreCase
+import com.example.barcodescanner.extension.unsafeLazy
+import java.util.Calendar
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class BoardingPass(
+    val name: String? = null,
+    val pnr: String? = null,
+    val from: String? = null,
+    val to: String? = null,
+    val carrier: String? = null,
+    val flight: String? = null,
+    val date: String? = null,
+    val cabin: String? = null,
+    val seat: String? = null,
+    val seq: String? = null,
+    val ticket: String? = null,
+    val selectee: String? = null,
+    val ffAirline: String? = null,
+    val ffNo: String? = null,
+    val fasttrack: String? = null,
+    val blob: String? = null,
+) : Schema {
+
+    companion object {
+        private const val TAG = "QRandBAR"
+        private val DATE_FORMATTER by unsafeLazy { SimpleDateFormat("d MMMM", Locale.ENGLISH) }
+
+        fun parse(text: String): BoardingPass? {
+
+            // M1 means single leg barcode
+            if (text.startsWithIgnoreCase("M1").not()) {
+                return null
+            }
+            // E means electronic ticket
+            if (text[22] != 'E') {
+                return null
+            }
+            val fieldSize: Int = text.slice(58..59).toInt(16)
+            // > is the marker for the airline specific optional fields
+            if (fieldSize != 0 && text[60] != '>') {
+                return null
+            }
+            // ^ is the mandatory security marker
+            if (text[60+fieldSize] != '^') {
+                return null
+            }
+
+            val name: String = text.slice(2..21).trim()
+            val pnr: String = text.slice(23..29).trim()
+            val from: String = text.slice(30..32)
+            val to: String = text.slice(33..35)
+            val carrier: String = text.slice(36..38).trim()
+            val flight: String = text.slice(39..43).trim()
+            val dateJ: String = text.slice(44..46)
+            val cabin: String = text.slice(47..47)
+            val seat: String = text.slice(48..51).trim()
+            val seq: String = text.slice(52..56).trim()
+            // 57 is status - ignore
+
+            val today = Calendar.getInstance()
+            today.set(Calendar.DAY_OF_YEAR, dateJ.toInt())
+            val date: String = DATE_FORMATTER.format(today.getTime())
+            var selectee : String = ""
+            var ticket : String = ""
+            var ffAirline : String = ""
+            var ffNo : String = ""
+            var fasttrack: String = ""
+
+            if (fieldSize != 0) {
+                val size: Int = text.slice(62..63).toInt(16)
+                if (size != 0 && size != 24) {
+                    return null
+                }
+                // don't really care about the first optional field
+                // it's mostly baggage and checkin information
+                val size1: Int = text.slice(64+size..65+size).toInt(16)
+                // European boarding passes are 42 to have appended fasttrack
+                // US boarding passes are size 41 with no fasttrack
+                if (size1 != 0 && size1 != 41 && size1 != 42) {
+                    return null
+                } else {
+                    ticket = text.slice(66+size..78+size).trim()
+                    // TSA field:
+                    // blank for not US flights
+                    // 0 - normal cleared
+                    // 1 - no fly
+                    // 2 - selected for enhanced security
+                    // 3 - precheck
+                    selectee = text.slice(79+size..79+size)
+                    ffAirline = text.slice(84+size..86+size).trim()
+                    ffNo = text.slice(87+size..102+size).trim()
+                    if (size1 == 42) {
+                        // Y - fasttrack eligible
+                        fasttrack = text.slice(107+size..107+size)
+                    }
+                }
+            }
+
+            return BoardingPass(name, pnr, from, to, carrier, flight, date,
+                                cabin, seat, seq, ticket, selectee,
+                                ffAirline, ffNo, fasttrack,
+                                text)
+        }
+    }
+
+    override val schema = BarcodeSchema.BOARDINGPASS
+    override fun toFormattedText(): String = listOf(name, pnr, "$from->$to", "$carrier$flight", date, cabin, seat, seq, ticket, selectee, "$ffAirline$ffNo", fasttrack).joinToStringNotNullOrBlankWithLineSeparator()
+    override fun toBarcodeText(): String = "$blob"
+}

--- a/app/src/main/java/com/example/barcodescanner/model/schema/Schema.kt
+++ b/app/src/main/java/com/example/barcodescanner/model/schema/Schema.kt
@@ -18,6 +18,7 @@ enum class BarcodeSchema {
     WIFI,
     YOUTUBE,
     NZCOVIDTRACER,
+    BOARDINGPASS,
     OTHER;
 }
 

--- a/app/src/main/java/com/example/barcodescanner/usecase/BarcodeParser.kt
+++ b/app/src/main/java/com/example/barcodescanner/usecase/BarcodeParser.kt
@@ -23,7 +23,8 @@ object BarcodeParser {
 
     fun parseSchema(format: BarcodeFormat, text: String): Schema {
         if (format != BarcodeFormat.QR_CODE) {
-            return Other(text)
+            return BoardingPass.parse(text)
+                   ?:Other(text)
         }
 
         return App.parse(text)
@@ -43,6 +44,7 @@ object BarcodeParser {
             ?: VCard.parse(text)
             ?: OtpAuth.parse(text)
             ?: NZCovidTracer.parse(text)
+            ?: BoardingPass.parse(text)
             ?: Other(text)
     }
 }

--- a/app/src/main/res/drawable/ic_boardingpass.xml
+++ b/app/src/main/res/drawable/ic_boardingpass.xml
@@ -1,0 +1,8 @@
+<!-- drawable/airplane.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M20.56 3.91C21.15 4.5 21.15 5.45 20.56 6.03L16.67 9.92L18.79 19.11L17.38 20.53L13.5 13.1L9.6 17L9.96 19.47L8.89 20.53L7.13 17.35L3.94 15.58L5 14.5L7.5 14.87L11.37 11L3.94 7.09L5.36 5.68L14.55 7.8L18.44 3.91C19 3.33 20 3.33 20.56 3.91Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,6 +363,7 @@
     <string name="barcode_schema_v_card">Contact (VCard)</string>
     <string name="barcode_schema_wifi">Wi-Fi</string>
     <string name="barcode_schema_youtube">Youtube URL</string>
+    <string name="barcode_schema_boardingpass">Boarding Pass</string>
     <string name="barcode_schema_other">Text</string>
 
     <!--Barcode formats-->


### PR DESCRIPTION
This is just a simple decoder to pull out the elements and display
them from any IATA compliant boarding pass.  It works with both paper
and electronic boarding passes.

The ic_boardingpass.xml file came from https://materialdesignicons.com/

Signed-off-by: James Bottomley <James.Bottomley@HansenPartnership.com>